### PR TITLE
Such features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ node_modules/
 static/bundle.js
 static/play-index.js
 static/package-lock.json
-
+bwrap-files/ubuntu-base/

--- a/GHCPool.hs
+++ b/GHCPool.hs
@@ -16,13 +16,9 @@ module GHCPool (
 import Control.Concurrent
 import Control.Exception (evaluate)
 import Control.Monad (replicateM)
-import Data.Char (isDigit)
-import Data.List (sort)
 import qualified System.Clock as Clock
-import System.Directory (listDirectory)
-import System.Environment (getEnv)
 import System.Exit (ExitCode(..))
-import System.FilePath ((</>), takeFileName)
+import System.FilePath ((</>))
 import System.IO (hPutStr, hGetContents, hClose)
 import System.Posix.Directory (getWorkingDirectory)
 import qualified System.Process as Pr

--- a/GHCPool.hs
+++ b/GHCPool.hs
@@ -43,10 +43,14 @@ availableVersions = do
   return ghc_versions
 
 data Command = CRun
+             | CCore
+             | CAsm
   deriving (Show)
 
 commandString :: Command -> String
 commandString CRun = "run"
+commandString CCore = "core"
+commandString CAsm = "asm"
 
 data Optimization = O0
                   | O1

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,25 @@
-.PHONY: reload-pages frontend frontend-dependencies
+.PHONY: all chroot frontend frontend-dependencies reload-pages
 
-reload-pages:
-	kill -s USR1 $$(ps -o pid,cmd -ww a | grep '/pastebin-haskell$$' | awk '{print $$1}')
+# These are not rule dependencies because we want to run them sequentially,
+# even if -j is in effect: chroot is interactive, and frontend-dependencies
+# needs to be run before frontend.
+all:
+	$(MAKE) chroot
+	$(MAKE) frontend-dependencies
+	$(MAKE) frontend
+
+chroot: bwrap-files/ubuntu-base
+	bwrap --bind bwrap-files/ubuntu-base / --ro-bind /etc/resolv.conf /etc/resolv.conf --tmpfs /tmp --dev /dev --proc /proc --new-session --unshare-all --share-net --die-with-parent --gid 0 --uid 0 --chdir / --ro-bind bwrap-files/chroot-initialise.sh /tmp/chinit.sh /bin/bash /tmp/chinit.sh
+
+bwrap-files/ubuntu-base:
+	mkdir '$@'
+	curl -L 'http://cdimage.ubuntu.com/ubuntu-base/releases/20.04/release/ubuntu-base-20.04.1-base-amd64.tar.gz' | tar -C '$@' -xz
 
 frontend:
 	$(MAKE) -C static/
 
 frontend-dependencies:
 	$(MAKE) -C static/ dependencies
+
+reload-pages:
+	kill -s USR1 $$(ps -o pid,cmd -ww a | grep '/pastebin-haskell$$' | awk '{print $$1}')

--- a/Play.hs
+++ b/Play.hs
@@ -4,9 +4,7 @@
 {-# LANGUAGE TypeApplications #-}
 module Play (playModule) where
 
-import Data.Maybe
 import Control.Concurrent (getNumCapabilities)
-import Control.Monad
 import Control.Monad.IO.Class (liftIO)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as BSB

--- a/Play.hs
+++ b/Play.hs
@@ -121,7 +121,9 @@ handleRequest gctx (Context pool) = \what -> case what of
                               _ -> pure O1
                             res <- liftIO $ runInPool pool runner (Version version) opt source
                             case res of
-                              Left err -> httpError 500 err
+                              Left EQueueFull -> httpError 500 "The queue is currently full, try again later"
+                              Left ETimeOut ->
+                                writeJSON $ JSON.makeObj [("ec", JSRational False (-1))]
                               Right result -> do
                                 -- Record the run as a spam-checking action, but don't actually act
                                 -- on the return value yet; that will come on the next user action

--- a/Play.hs
+++ b/Play.hs
@@ -100,9 +100,10 @@ handleRequest gctx (Context pool) = \case
                 Right postdata -> do
                   case runGetJSON JSON.readJSValue (UTF8.toString postdata) of
                     Right (JSObject (JSON.fromJSObject -> obj))
-                      | Just (JSString (JSON.fromJSString -> source)) <- lookup "source" obj
+                      | Just (JSString (JSON.fromJSString -> source))  <- lookup "source" obj
                       , Just (JSString (JSON.fromJSString -> version)) <- lookup "version" obj
-                      -> do res <- liftIO $ runInPool pool CRun (Version version) source
+                      , Just (JSString (JSON.fromJSString -> opt))     <- lookup "opt" obj
+                      -> do res <- liftIO $ runInPool pool CRun (Version version) (read opt) source
                             case res of
                               Left err -> httpError 500 err
                               Right result -> do

--- a/bwrap-files/chroot-initialise.sh
+++ b/bwrap-files/chroot-initialise.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+sed -i '/^_apt:/d' /etc/passwd  # See https://github.com/containers/bubblewrap/issues/210
+apt update && apt install -y build-essential curl libffi-dev libffi7 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5 locales
+PATH="$PATH:/usr/sbin" dpkg-reconfigure locales

--- a/bwrap-files/entry.sh
+++ b/bwrap-files/entry.sh
@@ -13,7 +13,7 @@ if [[ "${version//[0-9.]/}" != "" ]]; then
 	exit 1
 fi
 
-if ! ghcup --offline whereis ghc ${version} 2>/tmp/null 1>/tmp/null ; then
+if ! ghcup --offline whereis ghc "${version}" 2>/tmp/null 1>/tmp/null ; then
 	echo >&2 "Version ${version} not available"
 	exit 1
 fi
@@ -21,17 +21,17 @@ fi
 case "$command" in
 	run)
 		cat >input.hs
-		ghcup --offline run --ghc ${version} -- ghc -rtsopts -o Main "${opt}" input.hs 2>/tmp/null 1>/tmp/null
+		ghcup --offline run --ghc "${version}" -- ghc -rtsopts -o Main "${opt}" input.hs #2>/tmp/null 1>/tmp/null
 		./Main +RTS -M100m -RTS
 		;;
 	core)
 		cat >input.hs
-		ghcup --offline run --ghc ${version} -- ghc -ddump-simpl -ddump-to-file -o Main "${opt}" input.hs 2>/tmp/null 1>/tmp/null
+		ghcup --offline run --ghc "${version}" -- ghc -ddump-simpl -ddump-to-file -o Main "${opt}" input.hs 2>/tmp/null 1>/tmp/null
 		cat input.dump-simpl
 		;;
 	asm)
 		cat >input.hs
-		ghcup --offline run --ghc ${version} -- ghc -ddump-asm -ddump-to-file -o Main "${opt}" input.hs 2>/tmp/null 1>/tmp/null
+		ghcup --offline run --ghc "${version}" -- ghc -ddump-asm -ddump-to-file -o Main "${opt}" input.hs 2>/tmp/null 1>/tmp/null
 		cat input.dump-asm
 		;;
 

--- a/bwrap-files/entry.sh
+++ b/bwrap-files/entry.sh
@@ -21,8 +21,8 @@ fi
 case "$command" in
 	run)
 		cat >input.hs
-		ghcup --offline run --ghc ${version} -- ghc -o Main "${opt}" input.hs 2>/tmp/null 1>/tmp/null
-		./Main
+		ghcup --offline run --ghc ${version} -- ghc -rtsopts -o Main "${opt}" input.hs 2>/tmp/null 1>/tmp/null
+		./Main +RTS -M100m -RTS
 		;;
 	core)
 		cat >input.hs

--- a/bwrap-files/entry.sh
+++ b/bwrap-files/entry.sh
@@ -24,6 +24,16 @@ case "$command" in
 		ghcup --offline run --ghc ${version} -- ghc -o Main "${opt}" input.hs 2>/tmp/null 1>/tmp/null
 		./Main
 		;;
+	core)
+		cat >input.hs
+		ghcup --offline run --ghc ${version} -- ghc -ddump-simpl -ddump-to-file -o Main "${opt}" input.hs 2>/tmp/null 1>/tmp/null
+		cat input.dump-simpl
+		;;
+	asm)
+		cat >input.hs
+		ghcup --offline run --ghc ${version} -- ghc -ddump-asm -ddump-to-file -o Main "${opt}" input.hs 2>/tmp/null 1>/tmp/null
+		cat input.dump-asm
+		;;
 
 	*)
 		echo >&2 "Unknown command"

--- a/bwrap-files/entry.sh
+++ b/bwrap-files/entry.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 cd "$(dirname "$0")"
 
 IFS="" read -r command
-
+IFS="" read -r opt
 IFS="" read -r version
 
 # Check that there are only version-like characters
@@ -21,7 +21,8 @@ fi
 case "$command" in
 	run)
 		cat >input.hs
-		ghcup --offline run --ghc ${version} -- runhaskell input.hs
+		ghcup --offline run --ghc ${version} -- ghc -o Main "${opt}" input.hs 2>/tmp/null 1>/tmp/null
+		./Main
 		;;
 
 	*)

--- a/bwrap-files/entry.sh
+++ b/bwrap-files/entry.sh
@@ -13,15 +13,15 @@ if [[ "${version//[0-9.]/}" != "" ]]; then
 	exit 1
 fi
 
-if [[ ! -f "$HOME/.ghcup/bin/ghc-${version}" ]]; then
-	echo >&2 "Version not available"
+if ! ghcup --offline whereis ghc ${version} 2>/tmp/null 1>/tmp/null ; then
+	echo >&2 "Version ${version} not available"
 	exit 1
 fi
 
 case "$command" in
 	run)
 		cat >input.hs
-		"$HOME/.ghcup/bin/runhaskell-${version}" input.hs
+		ghcup --offline run --ghc ${version} -- runhaskell input.hs
 		;;
 
 	*)

--- a/bwrap-files/start.sh
+++ b/bwrap-files/start.sh
@@ -7,23 +7,25 @@ cd "$filesdir"
 homedir="$1"
 
 args=(
-  --ro-bind /bin /bin
-  --ro-bind /usr/bin /usr/bin
+  --ro-bind /bin/bash /bin/bash
+  --ro-bind /bin/gcc /bin/gcc
+  --ro-bind /bin/dirname /bin/dirname
+  --ro-bind /bin/cat /bin/cat
   --ro-bind /usr/lib /usr/lib
   --ro-bind /lib /lib
   --ro-bind /lib64 /lib64
-  --ro-bind /etc /etc
   --ro-bind "${homedir}/.ghcup/bin" "${homedir}/.ghcup/bin"
   --ro-bind "${homedir}/.ghcup/ghc" "${homedir}/.ghcup/ghc"
+  --symlink bash /bin/sh
+  --setenv PATH "/bin"
   --tmpfs /tmp
-  --dev /dev
   --proc /proc
   --dir "${homedir}/workdir"
   --new-session
   --unshare-all
   --die-with-parent
   --file 4 "${homedir}/workdir/entry.sh"
-  bash "${homedir}/workdir/entry.sh"
+  /bin/bash "${homedir}/workdir/entry.sh"
 )
 
 exec bwrap "${args[@]}" 4<"${filesdir}/entry.sh"

--- a/bwrap-files/start.sh
+++ b/bwrap-files/start.sh
@@ -4,28 +4,30 @@ set -euo pipefail
 filesdir="$(dirname "$0")"
 cd "$filesdir"
 
-homedir="$1"
+ghcup_base=$(ghcup whereis basedir)
+
+chroot=/home/hasufell/tmp/ubuntu
 
 args=(
-  --ro-bind /bin/bash /bin/bash
-  --ro-bind /bin/gcc /bin/gcc
-  --ro-bind /bin/dirname /bin/dirname
-  --ro-bind /bin/cat /bin/cat
-  --ro-bind /usr/lib /usr/lib
-  --ro-bind /lib /lib
-  --ro-bind /lib64 /lib64
-  --ro-bind "${homedir}/.ghcup/bin" "${homedir}/.ghcup/bin"
-  --ro-bind "${homedir}/.ghcup/ghc" "${homedir}/.ghcup/ghc"
-  --symlink bash /bin/sh
-  --setenv PATH "/bin"
   --tmpfs /tmp
+  --ro-bind "${chroot}"/bin /bin
+  --ro-bind "${chroot}"/usr/bin /usr/bin
+  --ro-bind "${chroot}"/usr/lib /usr/lib
+  --ro-bind "${chroot}"/lib /lib
+  --ro-bind "${chroot}"/lib64 /lib64
+  --dir "${ghcup_base}"
+  --ro-bind "${ghcup_base}/bin"   "${ghcup_base}/bin"
+  --ro-bind "${ghcup_base}/ghc"   "${ghcup_base}/ghc"
+  --ro-bind "${ghcup_base}/cache" "${ghcup_base}/cache"
+  --setenv PATH "/bin:/usr/bin:${ghcup_base}/bin"
+  --setenv GHCUP_INSTALL_BASE_PREFIX "$(dirname ${ghcup_base})"
   --proc /proc
-  --dir "${homedir}/workdir"
+  --chdir "/tmp"
   --new-session
   --unshare-all
   --die-with-parent
-  --file 4 "${homedir}/workdir/entry.sh"
-  /bin/bash "${homedir}/workdir/entry.sh"
+  --file 4 "/tmp/entry.sh"
+  /bin/bash "/tmp/entry.sh"
 )
 
 exec bwrap "${args[@]}" 4<"${filesdir}/entry.sh"

--- a/bwrap-files/start.sh
+++ b/bwrap-files/start.sh
@@ -6,16 +6,16 @@ cd "$filesdir"
 
 ghcup_base=$(ghcup whereis basedir)
 
-chroot=/home/hasufell/tmp/ubuntu
+chroot="${filesdir}/ubuntu-base"
 
 args=(
   --tmpfs /tmp
-  --ro-bind "${chroot}"/bin /bin
-  --ro-bind "${chroot}"/usr/bin /usr/bin
-  --ro-bind "${chroot}"/usr/lib /usr/lib
-  --ro-bind "${chroot}"/usr/include /usr/include
-  --ro-bind "${chroot}"/lib /lib
-  --ro-bind "${chroot}"/lib64 /lib64
+  --ro-bind "${chroot}/bin" /bin
+  --ro-bind "${chroot}/usr/bin" /usr/bin
+  --ro-bind "${chroot}/usr/lib" /usr/lib
+  --ro-bind "${chroot}/usr/include" /usr/include
+  --ro-bind "${chroot}/lib" /lib
+  --ro-bind "${chroot}/lib64" /lib64
   --dir "${ghcup_base}"
   --ro-bind "${ghcup_base}/bin"   "${ghcup_base}/bin"
   --ro-bind "${ghcup_base}/ghc"   "${ghcup_base}/ghc"

--- a/bwrap-files/start.sh
+++ b/bwrap-files/start.sh
@@ -13,6 +13,7 @@ args=(
   --ro-bind "${chroot}"/bin /bin
   --ro-bind "${chroot}"/usr/bin /usr/bin
   --ro-bind "${chroot}"/usr/lib /usr/lib
+  --ro-bind "${chroot}"/usr/include /usr/include
   --ro-bind "${chroot}"/lib /lib
   --ro-bind "${chroot}"/lib64 /lib64
   --dir "${ghcup_base}"

--- a/pastebin-haskell.cabal
+++ b/pastebin-haskell.cabal
@@ -1,4 +1,4 @@
-cabal-version:       >=1.10
+cabal-version:       2.0
 name:                pastebin-haskell
 synopsis:            Pastebin service in Haskell
 version:             0.2.14.0
@@ -43,6 +43,7 @@ executable pastebin-haskell
     process >= 1.6.14.0 && < 1.7,
     stm >= 2.5 && < 2.6,
     random >= 1.2.0 && < 1.3,
+    safe ^>=0.3,
     snap-server >= 1.1.1.2 && < 1.2,
     snap-core >= 1.0.4.2 && < 1.1,
     sqlite-simple >= 0.4.18 && < 0.5,

--- a/pastebin-haskell.cabal
+++ b/pastebin-haskell.cabal
@@ -33,7 +33,6 @@ executable pastebin-haskell
     bytestring >= 0.10.12 && < 0.11,
     containers >= 0.6.3.1 && < 0.7,
     clock >= 0.8 && < 0.9,
-    directory >= 1.3.7.0 && < 1.4,
     filepath >= 1.4.2.1 && < 1.5,
     io-streams,
     json >= 0.10 && < 0.11,

--- a/static/play-index.ts
+++ b/static/play-index.ts
@@ -78,8 +78,6 @@ function setWorking(yes: boolean) {
 		rightspinner.classList.add("invisible");
 		rightoutput.classList.remove("invisible");
 	}
-
-// <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
 }
 
 function getVersions(cb: (response: string) => void) {
@@ -88,8 +86,8 @@ function getVersions(cb: (response: string) => void) {
 	});
 }
 
-function sendRun(source: string, version: string, opt: string, run: Runner, cb: (response: json) => void, input?: string) {
-	const payload: string = JSON.stringify({source, version, opt, input});
+function sendRun(source: string, version: string, opt: string, run: Runner, cb: (response: json) => void) {
+	const payload: string = JSON.stringify({source, version, opt});
 	setWorking(true);
 	let ep: string = null;
 	switch (run) {
@@ -119,7 +117,7 @@ function doRun(run: Runner) {
 	let version = (document.getElementById("ghcversionselect") as any).value;
 	let opt = (document.getElementById("optselect") as any).value;
 	if (typeof version != "string" || version == "") version = "8.10.7";
-	if (typeof opt != "string" || version == "") opt = "O1";
+	if (typeof opt != "string" || opt == "") opt = "O1";
 
 	sendRun(source, version, opt, run, function(response: {[key: string]: json}) {
 		const ecNote: HTMLElement = document.getElementById("exitcode-note");

--- a/static/play-index.ts
+++ b/static/play-index.ts
@@ -70,8 +70,8 @@ function getVersions(cb: (response: string) => void) {
 	});
 }
 
-function sendRun(source: string, version: string, cb: (response: json) => void) {
-	const payload: string = JSON.stringify({source, version});
+function sendRun(source: string, version: string, opt: string, cb: (response: json) => void) {
+	const payload: string = JSON.stringify({source, version, opt});
 	setWorking(true);
 	performXHR("POST", "/play/run", "json",
 		function(res: json) {
@@ -87,9 +87,11 @@ function sendRun(source: string, version: string, cb: (response: json) => void) 
 function doRun() {
 	const source: string = (window as any).view.state.doc.toString();
 	let version = (document.getElementById("ghcversionselect") as any).value;
+	let opt = (document.getElementById("optselect") as any).value;
 	if (typeof version != "string" || version == "") version = "8.10.7";
+	if (typeof opt != "string" || version == "") opt = "O1";
 
-	sendRun(source, version, function(response: {[key: string]: json}) {
+	sendRun(source, version, opt, function(response: {[key: string]: json}) {
 		const ecNote: HTMLElement = document.getElementById("exitcode-note");
 		if (response.ec != 0) {
 			ecNote.classList.remove("invisible");
@@ -122,6 +124,14 @@ window.addEventListener("load", function() {
 			sel.appendChild(opt);
 		}
 	});
+	const sel: HTMLElement = document.getElementById("optselect");
+	["O0", "O1", "O2"].forEach(o => {
+		const opt: HTMLOptionElement = document.createElement("option");
+		opt.value = o;
+		opt.textContent = "-" + o;
+		if (o == "O1") opt.setAttribute("selected", "");
+		sel.appendChild(opt);
+	})
 });
 
 document.getElementById("btn-run").addEventListener('click', doRun);

--- a/static/play-index.ts
+++ b/static/play-index.ts
@@ -62,12 +62,24 @@ function performXHR(method: string, path: string, responseType: string, successc
 }
 
 function setWorking(yes: boolean) {
-	let elt: HTMLElement = document.getElementById("btn-run");
-	if (yes) elt.setAttribute("disabled", ""); else elt.removeAttribute("disabled");
+	const btns: Element[] = Array.from(document.getElementsByClassName("button"));
+	const rightspinner: HTMLElement = document.getElementById("output-spinner");
+	const rightoutput: HTMLElement = document.getElementById("output-pane");
+	if (yes) {
+		btns.forEach(btn => {
+			btn.setAttribute("disabled", "");
+		});
+		rightspinner.classList.remove("invisible");
+		rightoutput.classList.add("invisible");
+	} else {
+		btns.forEach(btn => {
+			btn.removeAttribute("disabled");
+		});
+		rightspinner.classList.add("invisible");
+		rightoutput.classList.remove("invisible");
+	}
 
-	elt = document.getElementById("rightcol");
-	if (yes) elt.classList.add("greytext");
-	else elt.classList.remove("greytext");
+// <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
 }
 
 function getVersions(cb: (response: string) => void) {
@@ -76,8 +88,8 @@ function getVersions(cb: (response: string) => void) {
 	});
 }
 
-function sendRun(source: string, version: string, opt: string, run: Runner, cb: (response: json) => void) {
-	const payload: string = JSON.stringify({source, version, opt});
+function sendRun(source: string, version: string, opt: string, run: Runner, cb: (response: json) => void, input?: string) {
+	const payload: string = JSON.stringify({source, version, opt, input});
 	setWorking(true);
 	let ep: string = null;
 	switch (run) {

--- a/static/play-index.ts
+++ b/static/play-index.ts
@@ -139,6 +139,8 @@ function doRun(run: Runner) {
 window.addEventListener("load", function() {
 	// // This is broken with the codemirror editor, of course, which rebinds
 	// // ctrl-enter to "insert blank line".
+	// // Note, if this is reinstated, please add a title= tooltip to the
+	// // relevant buttons in the html
 	// document.getElementById("editor").addEventListener("keypress", function(ev) {
 	//     if ((ev.key == "Enter" || ev.keyCode == 13) && ev.ctrlKey) {
 	//         doRun();

--- a/static/play-index.ts
+++ b/static/play-index.ts
@@ -123,7 +123,10 @@ function doRun(run: Runner) {
 
 	sendRun(source, version, opt, run, function(response: {[key: string]: json}) {
 		const ecNote: HTMLElement = document.getElementById("exitcode-note");
-		if (response.ec != 0) {
+		if (response.ec === -1) {
+			ecNote.classList.remove("invisible");
+			ecNote.textContent = "Command timed out :(";
+		} else if (response.ec != 0) {
 			ecNote.classList.remove("invisible");
 			ecNote.textContent = "Command exited with code " + response.ec + ".";
 		} else {

--- a/static/play.html
+++ b/static/play.html
@@ -75,6 +75,7 @@ header {
 	<div id="toolbar">
 		<input id="btn-run" type="button" value="Run" title="ctrl-Enter">
 		<select id="ghcversionselect"></select>
+		<select id="optselect"></select>
 	</div>
 </header>
 <div id="main">

--- a/static/play.html
+++ b/static/play.html
@@ -167,7 +167,7 @@ header {
 <header>
 	<div id="title">Haskell playground</div>
 	<div id="toolbar">
-		<input id="btn-run" type="button" class="button" value="Run" title="ctrl-Enter">
+		<input id="btn-run" type="button" class="button" value="Run">
 		<input id="btn-core" type="button" class="button" value="Core">
 		<input id="btn-asm" type="button" class="button" value="Asm">
 		<select id="ghcversionselect"></select>

--- a/static/play.html
+++ b/static/play.html
@@ -74,6 +74,8 @@ header {
 	<div id="title">Haskell playground</div>
 	<div id="toolbar">
 		<input id="btn-run" type="button" value="Run" title="ctrl-Enter">
+		<input id="btn-core" type="button" value="Core">
+		<input id="btn-asm" type="button" value="Asm">
 		<select id="ghcversionselect"></select>
 		<select id="optselect"></select>
 	</div>

--- a/static/play.html
+++ b/static/play.html
@@ -153,6 +153,9 @@ header {
 	font-size: x-large;
 }
 .cm-scroller { overflow: auto; }
+#exitcode {
+	margin-bottom: 25px;
+}
 #editor {
 	height: 100%;
 }

--- a/static/play.html
+++ b/static/play.html
@@ -61,7 +61,95 @@ header {
 	background-color: #fafafa;
 }
 .invisible {
-	display: none;
+	display: none !important;
+}
+.lds-roller {
+  display: block;
+  position: block;
+  width: 80px;
+  height: 80px;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 50%;
+  margin-bottom: 50%;
+}
+.lds-roller div {
+  animation: lds-roller 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+  transform-origin: 40px 40px;
+}
+.lds-roller div:after {
+  content: " ";
+  display: block;
+  position: absolute;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #000;
+  margin: -4px 0 0 -4px;
+}
+.lds-roller div:nth-child(1) {
+  animation-delay: -0.036s;
+}
+.lds-roller div:nth-child(1):after {
+  top: 63px;
+  left: 63px;
+}
+.lds-roller div:nth-child(2) {
+  animation-delay: -0.072s;
+}
+.lds-roller div:nth-child(2):after {
+  top: 68px;
+  left: 56px;
+}
+.lds-roller div:nth-child(3) {
+  animation-delay: -0.108s;
+}
+.lds-roller div:nth-child(3):after {
+  top: 71px;
+  left: 48px;
+}
+.lds-roller div:nth-child(4) {
+  animation-delay: -0.144s;
+}
+.lds-roller div:nth-child(4):after {
+  top: 72px;
+  left: 40px;
+}
+.lds-roller div:nth-child(5) {
+  animation-delay: -0.18s;
+}
+.lds-roller div:nth-child(5):after {
+  top: 71px;
+  left: 32px;
+}
+.lds-roller div:nth-child(6) {
+  animation-delay: -0.216s;
+}
+.lds-roller div:nth-child(6):after {
+  top: 68px;
+  left: 24px;
+}
+.lds-roller div:nth-child(7) {
+  animation-delay: -0.252s;
+}
+.lds-roller div:nth-child(7):after {
+  top: 63px;
+  left: 17px;
+}
+.lds-roller div:nth-child(8) {
+  animation-delay: -0.288s;
+}
+.lds-roller div:nth-child(8):after {
+  top: 56px;
+  left: 12px;
+}
+@keyframes lds-roller {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 .cm-editor { height: 800px; width:900px; border: 1px solid #ddd}
 .cm-scroller { overflow: auto; }
@@ -73,21 +161,24 @@ header {
 <header>
 	<div id="title">Haskell playground</div>
 	<div id="toolbar">
-		<input id="btn-run" type="button" value="Run" title="ctrl-Enter">
-		<input id="btn-core" type="button" value="Core">
-		<input id="btn-asm" type="button" value="Asm">
+		<input id="btn-run" type="button" class="button" value="Run" title="ctrl-Enter">
+		<input id="btn-core" type="button" class="button" value="Core">
+		<input id="btn-asm" type="button" class="button" value="Asm">
 		<select id="ghcversionselect"></select>
 		<select id="optselect"></select>
 	</div>
 </header>
 <div id="main">
 	<div id=editor></div>
-	<div id="rightcol">
-		<div id="exitcode-note" class="invisible"></div>
-		<div style="border-bottom: 1px #ccc solid">Errors</div>
-		<pre id="out-stderr"></pre>
-		<div style="border-bottom: 1px #ccc solid">Output</div>
-		<pre id="out-stdout"></pre>
+	<div id="rightcol">	
+		<div id="output-spinner" class="lds-roller invisible"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+		<div id="output-pane">
+			<div id="exitcode-note" class="invisible"></div>
+			<div style="border-bottom: 1px #ccc solid">Errors</div>
+			<pre id="out-stderr"></pre>
+			<div style="border-bottom: 1px #ccc solid">Output</div>
+			<pre id="out-stdout"></pre>
+		</div>
 	</div>
 </div>
 </body>

--- a/static/play.html
+++ b/static/play.html
@@ -18,6 +18,8 @@ body {
 }
 #main {
 	flex-grow: 1;
+	display: flex;
+	flex-direction: row;
 }
 header {
 	padding: 5px;
@@ -38,24 +40,18 @@ header {
 #toolbar input[type="button"] {
 	margin: 0 5px;
 }
-#main {
-	display: flex;
-	flex-direction: row;
+#code-ta {
+	flex-grow: 1;
 }
 #leftcol {
 	padding: 5px;
-	background-color: #e8e8e8;
 	width: 50%;
-	display: flex;
-	flex-direction: column;
-}
-#code-ta {
-	flex-grow: 1;
 }
 #rightcol {
 	padding: 5px;
 	background-color: #eee;
 	width: 50%;
+	font-size: x-large;
 }
 #rightcol pre {
 	background-color: #fafafa;
@@ -151,8 +147,15 @@ header {
     transform: rotate(360deg);
   }
 }
-.cm-editor { height: 800px; width:900px; border: 1px solid #ddd}
+.cm-editor {
+	height: 100%;
+	border: 1px solid #ddd;
+	font-size: x-large;
+}
 .cm-scroller { overflow: auto; }
+#editor {
+	height: 100%;
+}
 </style>
 <script type=module src="bundle.js">
 </script>
@@ -169,7 +172,9 @@ header {
 	</div>
 </header>
 <div id="main">
-	<div id=editor></div>
+	<div id="leftcol">	
+		<div id=editor></div>
+	</div>
 	<div id="rightcol">	
 		<div id="output-spinner" class="lds-roller invisible"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
 		<div id="output-pane">


### PR DESCRIPTION
I think ideally, it should point to a minimal chroot. `/lib64` right now is probably excessive. It also turns out we don't need `/etc`.

----

I was able to set up a chroot and then use this:

```
chroot=/home/hasufell/tmp/ubuntu

args=(
  --ro-bind "${chroot}"/bin /bin
  --ro-bind "${chroot}"/usr/bin /usr/bin
  --ro-bind "${chroot}"/usr/lib /usr/lib
  --ro-bind "${chroot}"/lib /lib
  --ro-bind "${chroot}"/lib64 /lib64
  --ro-bind "${homedir}/.ghcup/bin" "${homedir}/.ghcup/bin"
  --ro-bind "${homedir}/.ghcup/ghc" "${homedir}/.ghcup/ghc"
  --setenv PATH "/bin:/usr/bin"
  --tmpfs /tmp
  --proc /proc
  --dir "${homedir}/workdir"
  --new-session
  --unshare-all
  --die-with-parent
  --file 4 "${homedir}/workdir/entry.sh"
  /bin/bash "${homedir}/workdir/entry.sh"
)
```

Chroot created roughly like so:

1. download and unpack http://cdimage.ubuntu.com/ubuntu-base/releases/20.04/release/ubuntu-base-20.04.1-base-amd64.tar.gz
2. enter chroot with `bwrap --bind CHROOT_DIR / --ro-bind /etc/resolv.conf /etc/resolv.conf --tmpfs /tmp --dev /dev --proc /proc --new-session --unshare-all --share-net --die-with-parent --gid 0 --uid 0 --chdir / /bin/bash`
3. remove user `_apt` from `/etc/passwd` (see https://github.com/containers/bubblewrap/issues/210)
4. `apt update && apt install build-essential curl libffi-dev libffi7 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5 locales && dpkg-reconfigure locales`